### PR TITLE
[SIMP-1446] Prevent log duplication and log where intended

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class sudosh {
   }
 
   # named '0sudosh' so that it appears before the defaults
-  rsyslog::rule::local { '0sudosh':
+  rsyslog::rule::local { 'XX_sudosh':
     rule            => 'if ($programname == \'sudosh\') then',
     target_log_file => '/var/log/sudosh.log',
     stop_processing => true


### PR DESCRIPTION
Related to changes in default rsyslog rule naming in https://simp-project.atlassian.net/browse/SIMP-1446
