### PR TITLE
(SIMP-2222) Prevent log duplication and log where intended

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Thu Dec 01 2016 Nicholas Hughes, Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
+- Prevent log duplication and log where intended.
+- Changed naming to XX_ or YY_ to come before the default Z_default.conf
+  for local rules, but after the numbered configs used by the log_server
+  class.
+
 * Tue Nov 22 2016 Jeanne Greulich <jgreulich@onyxpoint.com> - 5.0.0-0
 - Major version bump for SIMP 6
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class sudosh {
     ensure => 'latest'
   }
 
-  # named '0sudosh' so that it appears before the defaults
+  # named 'XX_sudosh' so that it appears before the local filesystem defaults
   rsyslog::rule::local { 'XX_sudosh':
     rule            => 'if ($programname == \'sudosh\') then',
     target_log_file => '/var/log/sudosh.log',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class sudosh {
   }
 
   # named '0sudosh' so that it appears before the defaults
-  rsyslog::rule::local { '0sudosh':
+  rsyslog::rule::local { 'XX_sudosh':
     rule            => 'if ($programname == \'sudosh\') then',
     target_log_file => '/var/log/sudosh.log',
     stop_processing => true

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-sudosh",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "Manage sudosh",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -14,7 +14,7 @@ describe 'sudosh' do
         it { is_expected.to contain_package('sudosh2') }
 
         it do
-          is_expected.to contain_rsyslog__rule__local('0sudosh').with({
+          is_expected.to contain_rsyslog__rule__local('XX_sudosh').with({
             'rule' => "if ($programname == \'sudosh\') then",
             'target_log_file' => '/var/log/sudosh.log',
             'stop_processing' => true


### PR DESCRIPTION
- Changed naming to XX_ or YY_ to come before the default Z_default.conf
  for local rules, but after the numbered configs used by the log_server
  class.

SIMP-2222 #close
SIMP-1446 #comment related to changes in log_server